### PR TITLE
Upgrade core.async for clojure 1.9 compatibility

### DIFF
--- a/src/leiningen/parallel_test.clj
+++ b/src/leiningen/parallel_test.clj
@@ -18,7 +18,7 @@
     :sequence [:serial]})
 
 (def ^:private parallel-test-profile
-  {:dependencies [['org.clojure/core.async "0.2.395"]
+  {:dependencies [['org.clojure/core.async "0.4.474"]
                   ['com.holychao/parallel-test ptest/VERSION]
                   ['robert/hooke "1.3.0"]]})
 


### PR DESCRIPTION
Clojure 1.9 made a breaking change with respect to `:refer-clojure` syntax. It's fixed at : https://github.com/clojure/core.async/commit/2f87bc7c7d10cb7b0baafc86e08489d58fa87424 . Hence upgrade core.async to the latest stable version. Tested the same locally.

Closes https://github.com/aredington/parallel-test/issues/5